### PR TITLE
Feature node shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> I forked [votace/browser-cookies](https://github.com/voltace/browser-cookies) and shimmed out the API to do nothing (but not error out) in node.
-
 <img width="425" height="200" src="https://raw.githubusercontent.com/voltace/browser-cookies/master/browser-cookies.png"/>
 
 # browser-cookies

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> I forked [votace/browser-cookies](https://github.com/voltace/browser-cookies) and shimmed out the API to do nothing (but not error out) in node.
+
 <img width="425" height="200" src="https://raw.githubusercontent.com/voltace/browser-cookies/master/browser-cookies.png"/>
 
 # browser-cookies

--- a/src/browser-cookies.js
+++ b/src/browser-cookies.js
@@ -1,6 +1,10 @@
 exports.defaults = {};
 
 exports.set = function(name, value, options) {
+  if (typeof module !== 'undefined' && module.exports) {
+    return;
+  }
+  
   // Retrieve options and defaults
   var opts = options || {};
   var defaults = exports.defaults;
@@ -34,6 +38,10 @@ exports.set = function(name, value, options) {
 };
 
 exports.get = function(name) {
+  if (typeof module !== 'undefined' && module.exports) {
+    return null;
+  }
+  
   var cookies = document.cookie.split(';');
 
   // Iterate all cookies
@@ -57,6 +65,10 @@ exports.get = function(name) {
 };
 
 exports.erase = function(name, options) {
+  if (typeof module !== 'undefined' && module.exports) {
+    return;
+  }
+  
   exports.set(name, '', {
     expires:  -1,
     domain:   options && options.domain,

--- a/src/browser-cookies.js
+++ b/src/browser-cookies.js
@@ -1,8 +1,12 @@
+function isNode () {
+  return typeof(process.browser) === "undefined" && typeof module !== 'undefined' && module.exports;
+}
+
 exports.defaults = {};
 
 exports.set = function(name, value, options) {
-  if (typeof module !== 'undefined' && module.exports) {
-    return;
+  if (isNode()) {
+    return null;
   }
   
   // Retrieve options and defaults
@@ -38,7 +42,7 @@ exports.set = function(name, value, options) {
 };
 
 exports.get = function(name) {
-  if (typeof module !== 'undefined' && module.exports) {
+  if (isNode()) {
     return null;
   }
   
@@ -65,8 +69,8 @@ exports.get = function(name) {
 };
 
 exports.erase = function(name, options) {
-  if (typeof module !== 'undefined' && module.exports) {
-    return;
+  if (isNode()) {
+    return null;
   }
   
   exports.set(name, '', {


### PR DESCRIPTION
@voltace i'm using this module for a javascript "client" module that's consumed both by node and the browser. In the browser, i use browser-cookies to add a feature, but in node i do not.

currently, `require('browser-cookies')` in node results in a failure.

this change simply determines if the library is being used in node (using [the same method underscore uses](https://github.com/jashkenas/underscore/blob/master/underscore.js#L51)) and if so, shims out the methods to do nothing.