### PR TITLE
The Unlicense licence is spelled with an 's' and not 'c'

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "email": "support@voltace.com",
     "url": "http://www.voltace.com/"
   },
-  "license": "Unlicence",
+  "license": "Unlicense",
   "repository": {
     "type": "git",
     "url": "git://github.com/voltace/browser-cookies"


### PR DESCRIPTION
This just showed up in our internal license checker. 