### PR TITLE
Fix parentheses escapes

### DIFF
--- a/src/browser-cookies.js
+++ b/src/browser-cookies.js
@@ -24,8 +24,8 @@ exports.set = function(name, value, options) {
 
   // Set cookie
   document.cookie = name.replace(/[^+#$&^`|]/g, encodeURIComponent)                // Encode cookie name
-  .replace('(', '%28')
-  .replace(')', '%29') +
+  .replace(/\(/g, '%28')
+  .replace(/\)/g, '%29') +
   '=' + value.replace(/[^+#$&/:<-\[\]-}]/g, encodeURIComponent) +                  // Encode cookie value (RFC6265)
   (expDate && expDate.getTime() >= 0 ? ';expires=' + expDate.toUTCString() : '') + // Add expiration date
   (domain   ? ';domain=' + domain     : '') +                                      // Add domain


### PR DESCRIPTION
The current implementation only escapes the first instances of `(` and `)`, which does not appear to be correct.

This was caught by a scanning tool, and on manual review it indeed appears that the intent was to escape all instances.